### PR TITLE
Add correct import path and type

### DIFF
--- a/packages/core/test/scanning.spec.ts
+++ b/packages/core/test/scanning.spec.ts
@@ -1,4 +1,4 @@
-import { scanOutputs } from '../src';
+import { LabelMap, scanOutputs } from '../src';
 import { Buffer } from 'buffer';
 import { testData } from './fixtures/scanning';
 
@@ -20,7 +20,7 @@ describe('Scanning', () => {
                 Buffer.from(sumOfInputPublicKeys, 'hex'),
                 Buffer.from(inputHash, 'hex'),
                 outputs.map((output) => Buffer.from(output, 'hex')),
-                labels,
+                labels as LabelMap,
             );
 
             expect(result).toStrictEqual(

--- a/packages/wallet/test/wallet.spec.ts
+++ b/packages/wallet/test/wallet.spec.ts
@@ -1,8 +1,8 @@
 import * as fs from 'fs';
 import { BitcoinRpcClient } from './helpers/bitcoin-rpc-client';
 import { Wallet } from '../src';
-import { WalletDB } from '@silent-pay/level';
-import { EsploraClient } from '@silent-pay/esplora';
+import { WalletDB } from '@silent-pay/level/src';
+import { EsploraClient } from '@silent-pay/esplora/src';
 
 describe('Wallet', () => {
     let wallet: Wallet;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,6 +34,11 @@
       "@silent-pay/wallet": ["./packages/wallet/src"]
     }
   },
-  "include": ["src"],
+  "include": [
+    "packages/core/src",
+    "packages/esplora/src",
+    "packages/level/src",
+    "packages/wallet/src"
+  ],
   "exclude": ["**/*.spec.ts", "node_modules/**/*"]
 }


### PR DESCRIPTION
This PR updates the import paths for WalletDB and EsploraClient to ensure they correctly point to the respective module sources. Previously, the import paths were incomplete, which could lead to errors or issues during module resolution.

Fixed Label Type Issue in scanning.spec.ts: Resolves a type error in the scanning.spec.ts file by updating the labels type to LabelMap