### PR TITLE
Scan Silent Block for Incoming Payments

### DIFF
--- a/packages/core/test/fixtures/scanning.ts
+++ b/packages/core/test/fixtures/scanning.ts
@@ -542,3 +542,45 @@ export const testData = [
         expected: {},
     },
 ];
+
+export const scanTweakVectors = [
+    {
+        description: 'single matching output',
+        scanPrivateKey:
+            '38658693c017c46fd6b8bb94b8766c123cd5baf6026338305b6f59f82b36f9c0',
+        spendPublicKey:
+            '02833085c9a716d36b467552c00d6aa8bd42e39adbe98b05bc203110177192f702',
+        tweak: '02ccd442a997b40661a9a1e233884986a9c970f5da3b68514c6ea2533b708e2ae1',
+        outputs: [
+            '025a90a5fad7ab4d32e41fd02de786f7af3ecbe85bd18784e51e89a97c8693ca3c',
+        ],
+        expectedTweakHex:
+            '635aaddb7a1f7f64a6b78ddf47772ae987f6e29b79bb4eebbf1826f21af25e39',
+    },
+    {
+        description: 'no matching outputs',
+        scanPrivateKey:
+            '38658693c017c46fd6b8bb94b8766c123cd5baf6026338305b6f59f82b36f9c0',
+        spendPublicKey:
+            '02833085c9a716d36b467552c00d6aa8bd42e39adbe98b05bc203110177192f702',
+        tweak: '02ccd442a997b40661a9a1e233884986a9c970f5da3b68514c6ea2533b708e2ae1',
+        outputs: [
+            '03aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1',
+        ],
+        expectedTweakHex: null,
+    },
+    {
+        description: 'multiple matching outputs',
+        scanPrivateKey:
+            '38658693c017c46fd6b8bb94b8766c123cd5baf6026338305b6f59f82b36f9c0',
+        spendPublicKey:
+            '02833085c9a716d36b467552c00d6aa8bd42e39adbe98b05bc203110177192f702',
+        tweak: '02ccd442a997b40661a9a1e233884986a9c970f5da3b68514c6ea2533b708e2ae1',
+        outputs: [
+            '025a90a5fad7ab4d32e41fd02de786f7af3ecbe85bd18784e51e89a97c8693ca3c',
+            '025a90a5fad7ab4d32e41fd02de786f7af3ecbe85bd18784e51e89a97c8693ca3c',
+        ],
+        expectedTweakHex:
+            '635aaddb7a1f7f64a6b78ddf47772ae987f6e29b79bb4eebbf1826f21af25e39',
+    },
+];

--- a/packages/wallet/test/helpers/silent-block.fixtures.ts
+++ b/packages/wallet/test/helpers/silent-block.fixtures.ts
@@ -1,0 +1,17 @@
+export const parsedSilentBlock = {
+    type: 0,
+    transactions: [
+        {
+            txid: '7d77c249a6ade81248e1a2ba28e1128e3beee0a3727d6cc0b1bed13e07f12147',
+            scanTweak:
+                '02ccd442a997b40661a9a1e233884986a9c970f5da3b68514c6ea2533b708e2ae1',
+            outputs: [
+                {
+                    pubKey: '5a90a5fad7ab4d32e41fd02de786f7af3ecbe85bd18784e51e89a97c8693ca3c',
+                    value: 4000000,
+                    vout: 0,
+                },
+            ],
+        },
+    ],
+};


### PR DESCRIPTION
This PR introduces functionality to scan silent blocks for incoming payments. Using scanTweak to identify outputs, matches transactions using the public key, and subsequently saves the coins.