### PR TITLE
Migration from Buffer to Uint8Array

### DIFF
--- a/packages/core/src/bytes.ts
+++ b/packages/core/src/bytes.ts
@@ -1,0 +1,46 @@
+/**
+ * Convert hex string to Uint8Array
+ */
+export function fromHex(hex: string): Uint8Array {
+    const result = new Uint8Array(hex.length / 2);
+    for (let i = 0; i < hex.length; i += 2) {
+        result[i / 2] = parseInt(hex.substr(i, 2), 16);
+    }
+    return result;
+}
+
+/**
+ * Convert Uint8Array to hex string
+ */
+export function toHex(arr: Uint8Array): string {
+    return Array.from(arr, byte => byte.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * Concatenate Uint8Arrays
+ */
+export function concat(arrays: Uint8Array[]): Uint8Array {
+    const result = new Uint8Array(arrays.reduce((sum, arr) => sum + arr.length, 0));
+    let offset = 0;
+    for (const array of arrays) {
+        result.set(array, offset);
+        offset += array.length;
+    }
+    return result;
+}
+
+/**
+ * Create DataView for efficient integer operations
+ */
+export function createView(arr: Uint8Array, offset = 0): DataView {
+    return new DataView(arr.buffer, arr.byteOffset + offset);
+}
+
+/**
+ * Reverse array in place (like Buffer.reverse())
+ */
+export function reverse(arr: Uint8Array): Uint8Array {
+    const result = new Uint8Array(arr);
+    result.reverse();
+    return result;
+}

--- a/packages/core/src/encoding.ts
+++ b/packages/core/src/encoding.ts
@@ -1,6 +1,6 @@
 import { bech32m } from 'bech32';
 import secp256k1 from 'secp256k1';
-import { Buffer } from 'buffer';
+import { concat, toHex } from './bytes.ts';
 import { Network } from 'bitcoinjs-lib';
 import { bitcoin } from 'bitcoinjs-lib/src/networks';
 import {
@@ -17,7 +17,7 @@ export const encodeSilentPaymentAddress = (
     network: Network = bitcoin,
     version: number = 0,
 ): string => {
-    const data = bech32m.toWords(Buffer.concat([scanPubKey, spendPubKey]));
+    const data = bech32m.toWords(concat([scanPubKey, spendPubKey]));
     data.unshift(version);
 
     return bech32m.encode(hrpFromNetwork(network), data, 1023);
@@ -26,14 +26,14 @@ export const encodeSilentPaymentAddress = (
 export const decodeSilentPaymentAddress = (
     address: string,
     network: Network = bitcoin,
-): { scanKey: Buffer; spendKey: Buffer } => {
+): { scanKey: Uint8Array; spendKey: Uint8Array } => {
     const { prefix, words } = bech32m.decode(address, 1023);
     if (prefix != hrpFromNetwork(network)) throw new Error('Invalid prefix!');
 
     const version = words.shift();
     if (version != 0) throw new Error('Invalid version!');
 
-    const key = Buffer.from(bech32m.fromWords(words));
+    const key = new Uint8Array(bech32m.fromWords(words));
 
     return {
         scanKey: key.slice(0, 33),
@@ -50,7 +50,7 @@ export const createLabeledSilentPaymentAddress = (
 ) => {
     const label = createTaggedHash(
         'BIP0352/Label',
-        Buffer.concat([scanPrivKey, serialiseUint32(m)]),
+        concat([scanPrivKey, serialiseUint32(m)]),
     );
     const scanPubKey = secp256k1.publicKeyCreate(scanPrivKey);
     const tweakedSpendPubKey = secp256k1.publicKeyTweakAdd(
@@ -70,15 +70,16 @@ const hrpFromNetwork = (network: Network): string => {
     return network.bech32 === 'bc' ? 'sp' : 'tsp';
 };
 
-export const parseSilentBlock = (data: Buffer): SilentBlock => {
-    const type = data.readUInt8(0);
+export const parseSilentBlock = (data: Uint8Array): SilentBlock => {
+    const view = new DataView(data.buffer, data.byteOffset);
+    const type = data[0];
     const transactions = [];
     let cursor = 1;
     const count = readVarInt(data, cursor);
     cursor += encodingLength(count);
 
     for (let i = 0; i < count; i++) {
-        const txid = data.subarray(cursor, cursor + 32).toString('hex');
+        const txid = toHex(data.subarray(cursor, cursor + 32));
         cursor += 32;
 
         const outputs = [];
@@ -86,19 +87,19 @@ export const parseSilentBlock = (data: Buffer): SilentBlock => {
         cursor += encodingLength(outputCount);
 
         for (let j = 0; j < outputCount; j++) {
-            const value = Number(data.readBigUInt64BE(cursor));
+            const value = Number(view.getBigUint64(cursor, false)); // big-endian
             cursor += 8;
 
-            const pubKey = data.subarray(cursor, cursor + 32).toString('hex');
+            const pubKey = toHex(data.subarray(cursor, cursor + 32));
             cursor += 32;
 
-            const vout = data.readUint32BE(cursor);
+            const vout = view.getUint32(cursor, false); // big-endian
             cursor += 4;
 
             outputs.push({ value, pubKey, vout });
         }
 
-        const scanTweak = data.subarray(cursor, cursor + 33).toString('hex');
+        const scanTweak = toHex(data.subarray(cursor, cursor + 33));
         cursor += 33;
 
         transactions.push({ txid, outputs, scanTweak });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+export * from './bytes.ts';
 export * from './constants.ts';
 export * from './encoding.ts';
 export * from './interface.ts';

--- a/packages/core/src/interface.ts
+++ b/packages/core/src/interface.ts
@@ -1,5 +1,3 @@
-import { Buffer } from 'buffer';
-
 export type Outpoint = {
     txid: string;
     vout: number;
@@ -16,18 +14,18 @@ export type RecipientAddress = {
 };
 
 export type Output = {
-    script: Buffer;
+    script: Uint8Array;
     value: number;
 };
 
 export type LabelMap = { [key: string]: string };
 
 export type Input = {
-    hash: Buffer;
+    hash: Uint8Array;
     index: number;
-    script: Buffer;
+    script: Uint8Array;
     sequence: number;
-    witness: Buffer[];
+    witness: Uint8Array[];
 };
 
 export type SilentBlock = {

--- a/packages/core/src/outputs.ts
+++ b/packages/core/src/outputs.ts
@@ -7,7 +7,7 @@ import {
 } from './utility.ts';
 import { decodeSilentPaymentAddress } from './encoding.ts';
 import secp256k1 from 'secp256k1';
-import { Buffer } from 'buffer';
+import { toHex, concat } from './bytes.ts';
 import { bitcoin } from 'bitcoinjs-lib/src/networks';
 import { Network } from 'bitcoinjs-lib';
 
@@ -19,13 +19,13 @@ export const createOutputs = (
 ): Output[] => {
     const sumOfPrivateKeys = calculateSumOfPrivateKeys(inputPrivateKeys);
     const inputHash = createInputHash(
-        Buffer.from(secp256k1.publicKeyCreate(sumOfPrivateKeys)),
+        new Uint8Array(secp256k1.publicKeyCreate(sumOfPrivateKeys)),
         smallestOutpoint,
     );
 
     const paymentGroups = new Map<
         string,
-        { spendKey: Buffer; amount: number }[]
+        { spendKey: Uint8Array; amount: number }[]
     >();
 
     for (const { address, amount } of recipientAddresses) {
@@ -33,18 +33,21 @@ export const createOutputs = (
             address,
             network,
         );
-        if (paymentGroups.has(scanKey.toString('hex'))) {
+        if (paymentGroups.has(toHex(scanKey))) {
             paymentGroups
-                .get(scanKey.toString('hex'))
+                .get(toHex(scanKey))
                 ?.push({ spendKey, amount });
         } else {
-            paymentGroups.set(scanKey.toString('hex'), [{ spendKey, amount }]);
+            paymentGroups.set(toHex(scanKey), [{ spendKey, amount }]);
         }
     }
 
     const outputs: Output[] = [];
     for (const [scanKeyHex, paymentGroup] of paymentGroups.entries()) {
-        const scanKey = Buffer.from(scanKeyHex, 'hex');
+        const scanKey = new Uint8Array(scanKeyHex.length / 2);
+        for (let i = 0; i < scanKeyHex.length; i += 2) {
+            scanKey[i / 2] = parseInt(scanKeyHex.substr(i, 2), 16);
+        }
         const ecdhSecret = secp256k1.publicKeyTweakMul(
             secp256k1.publicKeyTweakMul(scanKey, inputHash, true),
             sumOfPrivateKeys,
@@ -54,7 +57,7 @@ export const createOutputs = (
         for (const { spendKey, amount } of paymentGroup) {
             const tweak = createTaggedHash(
                 'BIP0352/SharedSecret',
-                Buffer.concat([Buffer.from(ecdhSecret), serialiseUint32(n)]),
+                concat([new Uint8Array(ecdhSecret), serialiseUint32(n)]),
             );
 
             const publicKey = secp256k1.publicKeyTweakAdd(
@@ -64,7 +67,7 @@ export const createOutputs = (
             );
 
             outputs.push({
-                script: Buffer.from(publicKey),
+                script: new Uint8Array(publicKey),
                 value: amount,
             });
             n++;

--- a/packages/core/src/transaction.ts
+++ b/packages/core/src/transaction.ts
@@ -1,7 +1,7 @@
 import { WITNESS_FLAG, WITNESS_MARKER } from './constants.ts';
 import { encodingLength, isPubKey, readVarInt } from './utility.ts';
 import { Input, Output } from './interface.ts';
-import { Buffer } from 'buffer';
+import { fromHex, createView } from './bytes.ts';
 
 export class Transaction {
     version: number;
@@ -16,15 +16,16 @@ export class Transaction {
         this.locktime = 0;
     }
 
-    static fromBuffer(buffer: Buffer): Transaction {
+    static fromBuffer(buffer: Uint8Array): Transaction {
         const tx = new Transaction();
+        const view = createView(buffer);
         let offset = 0;
-        tx.version = buffer.readInt32LE(offset);
+        tx.version = view.getInt32(offset, true);
         offset += 4;
 
         const hasWitnesses =
-            buffer.readUInt8(offset) === WITNESS_MARKER &&
-            buffer.readUInt8(offset + 1) === WITNESS_FLAG;
+            buffer[offset] === WITNESS_MARKER &&
+            buffer[offset + 1] === WITNESS_FLAG;
         offset += hasWitnesses ? 2 : 0;
 
         const vinLen = readVarInt(buffer, offset);
@@ -32,13 +33,13 @@ export class Transaction {
         for (let i = 0; i < vinLen; i++) {
             const hash = buffer.subarray(offset, offset + 32);
             offset += 32;
-            const index = buffer.readUInt32LE(offset);
+            const index = createView(buffer, offset).getUint32(0, true);
             offset += 4;
             const scriptSize = readVarInt(buffer, offset);
             offset += encodingLength(scriptSize);
             const script = buffer.subarray(offset, offset + scriptSize);
             offset += scriptSize;
-            const sequence = buffer.readUInt32LE(offset);
+            const sequence = createView(buffer, offset).getUint32(0, true);
             offset += 4;
             tx.inputs.push({
                 hash: hash,
@@ -52,7 +53,7 @@ export class Transaction {
         const voutLen = readVarInt(buffer, offset);
         offset += encodingLength(vinLen);
         for (let i = 0; i < voutLen; i++) {
-            const value = buffer.readBigUint64LE(offset);
+            const value = createView(buffer, offset).getBigUint64(0, true);
             offset += 8;
             const scriptSize = readVarInt(buffer, offset);
             offset += encodingLength(scriptSize);
@@ -68,7 +69,7 @@ export class Transaction {
             for (let i = 0; i < vinLen; i++) {
                 const vectorSize = readVarInt(buffer, offset);
                 offset += encodingLength(vectorSize);
-                const vector: Buffer[] = [];
+                const vector: Uint8Array[] = [];
                 for (let j = 0; j < vectorSize; j++) {
                     const witnessItemLen = readVarInt(buffer, offset);
                     offset += encodingLength(witnessItemLen);
@@ -81,7 +82,7 @@ export class Transaction {
             }
         }
 
-        tx.locktime = buffer.readUInt32LE(offset);
+        tx.locktime = createView(buffer, offset).getUint32(0, true);
         offset += 4;
 
         if (offset !== buffer.length)
@@ -91,10 +92,10 @@ export class Transaction {
     }
 
     static fromHex(hex: string): Transaction {
-        return Transaction.fromBuffer(Buffer.from(hex, 'hex'));
+        return Transaction.fromBuffer(fromHex(hex));
     }
 
-    getPublicKeyFromOutput(index: number): Buffer | null {
+    getPublicKeyFromOutput(index: number): Uint8Array | null {
         const output = this.outputs[index];
 
         // taproot
@@ -127,10 +128,10 @@ export class Transaction {
         return null;
     }
 
-    getPublicKeyFromInput(index: number): Buffer | null {
+    getPublicKeyFromInput(index: number): Uint8Array | null {
         const input = this.inputs[index];
 
-        const scriptVector: Buffer[] = [];
+        const scriptVector: Uint8Array[] = [];
         const buffer = input.script;
         for (let offset = 0; offset < buffer.byteLength; ) {
             const sigItemLen = readVarInt(buffer, offset);

--- a/packages/core/src/utility.ts
+++ b/packages/core/src/utility.ts
@@ -1,17 +1,17 @@
 import { Outpoint, PrivateKey } from './interface.ts';
 import secp256k1 from 'secp256k1';
 import createHash from 'create-hash';
-import { Buffer } from 'buffer';
+import { fromHex, concat, reverse, createView } from './bytes.ts';
 
 export const createInputHash = (
-    sumOfInputPublicKeys: Buffer,
+    sumOfInputPublicKeys: Uint8Array,
     outpoint: Outpoint,
-): Buffer => {
+): Uint8Array => {
     return createTaggedHash(
         'BIP0352/Inputs',
-        Buffer.concat([
-            Buffer.concat([
-                Buffer.from(outpoint.txid, 'hex').reverse(),
+        concat([
+            concat([
+                reverse(fromHex(outpoint.txid)),
                 serialiseUint32LE(outpoint.vout),
             ]),
             sumOfInputPublicKeys,
@@ -19,18 +19,18 @@ export const createInputHash = (
     );
 };
 
-export const createTaggedHash = (tag: string, buffer: Buffer): Buffer => {
+export const createTaggedHash = (tag: string, buffer: Uint8Array): Uint8Array => {
     const tagHash = createHash('sha256').update(tag, 'utf8').digest();
-    return createHash('sha256')
+    return new Uint8Array(createHash('sha256')
         .update(tagHash)
         .update(tagHash)
         .update(buffer)
-        .digest();
+        .digest());
 };
 
-export const calculateSumOfPrivateKeys = (keys: PrivateKey[]): Buffer => {
+export const calculateSumOfPrivateKeys = (keys: PrivateKey[]): Uint8Array => {
     const negatedKeys = keys.map((key) => {
-        const privateKey = Buffer.from(key.key, 'hex');
+        const privateKey = fromHex(key.key);
         if (
             key.isXOnly &&
             secp256k1.publicKeyCreate(privateKey, true)[0] === 0x03
@@ -40,38 +40,39 @@ export const calculateSumOfPrivateKeys = (keys: PrivateKey[]): Buffer => {
         return privateKey;
     });
 
-    return Buffer.from(
+    return new Uint8Array(
         negatedKeys.slice(1).reduce((acc, key) => {
             return secp256k1.privateKeyTweakAdd(acc, key);
         }, negatedKeys[0]),
     );
 };
 
-export const serialiseUint32 = (n: number): Buffer => {
-    const buf = Buffer.alloc(4);
-    buf.writeUInt32BE(n);
+export const serialiseUint32 = (n: number): Uint8Array => {
+    const buf = new Uint8Array(4);
+    createView(buf).setUint32(0, n, false); // big-endian
     return buf;
 };
 
-const serialiseUint32LE = (n: number): Buffer => {
-    const buf = Buffer.alloc(4);
-    buf.writeUInt32LE(n);
+const serialiseUint32LE = (n: number): Uint8Array => {
+    const buf = new Uint8Array(4);
+    createView(buf).setUint32(0, n, true); // little-endian
     return buf;
 };
 
-export const readVarInt = (buffer: Buffer, offset: number = 0): number => {
-    const first = buffer.readUInt8(offset);
+export const readVarInt = (buffer: Uint8Array, offset: number = 0): number => {
+    const view = createView(buffer, offset);
+    const first = buffer[offset];
 
     // 8 bit
     if (first < 0xfd) return first;
     // 16 bit
-    else if (first === 0xfd) return buffer.readUInt16LE(offset + 1);
+    else if (first === 0xfd) return view.getUint16(1, true);
     // 32 bit
-    else if (first === 0xfe) return buffer.readUInt32LE(offset + 1);
+    else if (first === 0xfe) return view.getUint32(1, true);
     // 64 bit
     else {
-        const lo = buffer.readUInt32LE(offset + 1);
-        const hi = buffer.readUInt32LE(offset + 5);
+        const lo = view.getUint32(1, true);
+        const hi = view.getUint32(5, true);
         return hi * 0x0100000000 + lo;
     }
 };
@@ -80,7 +81,7 @@ export const encodingLength = (n: number) => {
     return n < 0xfd ? 1 : n <= 0xffff ? 3 : n <= 0xffffffff ? 5 : 9;
 };
 
-export const isPubKey = (testVector: Buffer): boolean => {
+export const isPubKey = (testVector: Uint8Array): boolean => {
     return (
         (testVector.length == 33 || testVector.length == 65) &&
         secp256k1.publicKeyVerify(testVector)

--- a/packages/core/test/encoding.spec.ts
+++ b/packages/core/test/encoding.spec.ts
@@ -3,8 +3,8 @@ import {
     decodeSilentPaymentAddress,
     encodeSilentPaymentAddress,
     parseSilentBlock,
+    fromHex,
 } from '../src';
-import { Buffer } from 'buffer';
 import { unlabelled, labelled, silentBlock } from './fixtures/encoding';
 
 describe('Encoding', () => {
@@ -12,17 +12,16 @@ describe('Encoding', () => {
         it('should encode scan and spend key to silent payment address', () => {
             expect(
                 encodeSilentPaymentAddress(
-                    Buffer.from(data.scanKey, 'hex'),
-                    Buffer.from(data.spendKey, 'hex'),
+                    fromHex(data.scanKey),
+                    fromHex(data.spendKey),
                 ),
             ).toBe(data.address);
         });
 
         it('should decode scan and spend key from silent payment address', () => {
-            expect(decodeSilentPaymentAddress(data.address)).toStrictEqual({
-                scanKey: Buffer.from(data.scanKey, 'hex'),
-                spendKey: Buffer.from(data.spendKey, 'hex'),
-            });
+            const decoded = decodeSilentPaymentAddress(data.address);
+            expect(decoded.scanKey).toEqual(fromHex(data.scanKey));
+            expect(decoded.spendKey).toEqual(fromHex(data.spendKey));
         });
     });
 
@@ -31,8 +30,8 @@ describe('Encoding', () => {
         ({ scanPrivKey, spendPubKey, label, address }) => {
             expect(
                 createLabeledSilentPaymentAddress(
-                    Buffer.from(scanPrivKey, 'hex'),
-                    Buffer.from(spendPubKey, 'hex'),
+                    fromHex(scanPrivKey),
+                    fromHex(spendPubKey),
                     label,
                 ),
             ).toBe(address);
@@ -41,7 +40,7 @@ describe('Encoding', () => {
 
     it.each(silentBlock)('should parse silent block', (blockData) => {
         const parsedBlock = parseSilentBlock(
-            Buffer.from(blockData.encodedBlockHex, 'hex'),
+            fromHex(blockData.encodedBlockHex),
         );
         expect(parsedBlock).toStrictEqual(blockData.parsedBlock);
     });

--- a/packages/core/test/outputs.spec.ts
+++ b/packages/core/test/outputs.spec.ts
@@ -1,4 +1,4 @@
-import { createOutputs } from '../src';
+import { createOutputs, toHex } from '../src';
 import { testData } from './fixtures/outputs';
 
 describe('Outputs', () => {
@@ -13,7 +13,7 @@ describe('Outputs', () => {
             expect(
                 outputs
                     .map((output) => ({
-                        pubkey: output.script.toString('hex'),
+                        pubkey: toHex(output.script),
                         value: output.value,
                     }))
                     .sort((a, b) => a.pubkey.localeCompare(b.pubkey)),

--- a/packages/core/test/scanning.spec.ts
+++ b/packages/core/test/scanning.spec.ts
@@ -1,5 +1,4 @@
-import { LabelMap, scanOutputs, scanOutputsWithTweak } from '../src';
-import { Buffer } from 'buffer';
+import { LabelMap, scanOutputs, scanOutputsWithTweak, fromHex, toHex } from '../src';
 import { testData, scanTweakVectors } from './fixtures/scanning';
 
 describe('Scanning', () => {
@@ -15,11 +14,11 @@ describe('Scanning', () => {
             expected,
         }) => {
             const result = scanOutputs(
-                Buffer.from(scanPrivateKey, 'hex'),
-                Buffer.from(spendPublicKey, 'hex'),
-                Buffer.from(sumOfInputPublicKeys, 'hex'),
-                Buffer.from(inputHash, 'hex'),
-                outputs.map((output) => Buffer.from(output, 'hex')),
+                fromHex(scanPrivateKey),
+                fromHex(spendPublicKey),
+                fromHex(sumOfInputPublicKeys),
+                fromHex(inputHash),
+                outputs.map((output) => fromHex(output)),
                 labels as LabelMap,
             );
 
@@ -27,7 +26,7 @@ describe('Scanning', () => {
                 new Map(
                     Object.entries(expected).map(([output, tweak]) => [
                         output,
-                        Buffer.from(tweak as string, 'hex'),
+                        fromHex(tweak as string),
                     ]),
                 ),
             );
@@ -44,10 +43,10 @@ describe('Scanning', () => {
             expectedTweakHex,
         }) => {
             const res = scanOutputsWithTweak(
-                Buffer.from(scanPrivateKey, 'hex'),
-                Buffer.from(spendPublicKey, 'hex'),
-                Buffer.from(tweak, 'hex'),
-                outputs.map((o) => Buffer.from(o, 'hex')),
+                fromHex(scanPrivateKey),
+                fromHex(spendPublicKey),
+                fromHex(tweak),
+                outputs.map((o) => fromHex(o)),
             );
 
             if (!expectedTweakHex) {
@@ -55,7 +54,7 @@ describe('Scanning', () => {
             } else {
                 expect(res.size).toBeGreaterThan(0);
                 for (const [output, foundTweak] of res) {
-                    expect(foundTweak.toString('hex')).toBe(expectedTweakHex);
+                    expect(toHex(foundTweak)).toBe(expectedTweakHex);
                     expect(output).toBeDefined();
                 }
             }

--- a/packages/core/test/transaction.spec.ts
+++ b/packages/core/test/transaction.spec.ts
@@ -1,4 +1,4 @@
-import { Transaction } from '../src';
+import { Transaction, toHex } from '../src';
 import { validTransactions } from './fixtures/transaction';
 
 describe('Transaction', () => {
@@ -12,11 +12,11 @@ describe('Transaction', () => {
             expect(
                 transaction.inputs
                     .map((inp) => ({
-                        hash: inp.hash.toString('hex'),
+                        hash: toHex(inp.hash),
                         index: inp.index,
-                        script: inp.script.toString('hex'),
+                        script: toHex(inp.script),
                         sequence: inp.sequence,
-                        witness: inp.witness.map((w) => w.toString('hex')),
+                        witness: inp.witness.map((w) => toHex(w)),
                     }))
                     .sort(
                         (a, b) =>
@@ -31,7 +31,7 @@ describe('Transaction', () => {
             expect(
                 transaction.outputs
                     .map((out) => ({
-                        script: out.script.toString('hex'),
+                        script: toHex(out.script),
                         value: out.value,
                     }))
                     .sort(
@@ -74,7 +74,7 @@ describe('Transaction', () => {
         const transaction = Transaction.fromHex(tx.hex);
         const receivedInPubkeys = tx.raw.ins.map((_, index) => {
             const PK = transaction.getPublicKeyFromInput(index);
-            return PK ? PK?.toString('hex') : PK;
+            return PK ? toHex(PK) : PK;
         });
         expect(receivedInPubkeys).toStrictEqual(tx.raw.inPubkeys);
     });

--- a/packages/core/test/utility.spec.ts
+++ b/packages/core/test/utility.spec.ts
@@ -4,6 +4,8 @@ import {
     createInputHash,
     PrivateKey,
     isPubKey,
+    fromHex,
+    toHex,
 } from '../src';
 import {
     createTaggedHashData,
@@ -18,15 +20,15 @@ describe('Utility', () => {
         async (data: { keys: PrivateKey[]; expected: string }) => {
             const { keys, expected } = data;
             const sum = calculateSumOfPrivateKeys(keys);
-            expect(sum.toString('hex')).toBe(expected);
+            expect(toHex(sum)).toBe(expected);
         },
     );
 
     it.each(createTaggedHashData)(
         'should calculate tagged hash',
         ({ tag, hex, expected }) => {
-            const taggedHash = createTaggedHash(tag, Buffer.from(hex, 'hex'));
-            expect(taggedHash.toString('hex')).toBe(expected);
+            const taggedHash = createTaggedHash(tag, fromHex(hex));
+            expect(toHex(taggedHash)).toBe(expected);
         },
     );
 
@@ -34,17 +36,17 @@ describe('Utility', () => {
         'should calculate input hash',
         ({ sumOfInputPublicKeys, outpoint, expected }) => {
             const inputHash = createInputHash(
-                Buffer.from(sumOfInputPublicKeys, 'hex'),
+                fromHex(sumOfInputPublicKeys),
                 outpoint,
             );
-            expect(inputHash.toString('hex')).toBe(expected);
+            expect(toHex(inputHash)).toBe(expected);
         },
     );
 
     it.each(publicKeysTestData)(
         'should test for public key validity',
         ({ publickKey, valid }) => {
-            expect(isPubKey(Buffer.from(publickKey, 'hex'))).toStrictEqual(
+            expect(isPubKey(fromHex(publickKey))).toStrictEqual(
                 valid,
             );
         },

--- a/packages/wallet/test/coinselector.spec.ts
+++ b/packages/wallet/test/coinselector.spec.ts
@@ -54,7 +54,7 @@ describe('CoinSelector', () => {
             // Set the transaction output value with a random output script.
             // Random 20 bytes and `0014${randomBytes.toString()}` will be a valid P2WPKH script.
             transaction.addOutput(
-                Buffer.from(`0014${crypto.randomBytes(20).toString('hex')}`), // Ensure the first parameter passed to addOutput is a Buffer.
+                Buffer.from(`0014${crypto.randomBytes(20).toString('hex')}`, 'hex'), // Ensure the first parameter passed to addOutput is a Buffer.
                 txOutValue,
             );
 


### PR DESCRIPTION
## Fixes #59  

### Changes Added  

- **Created `bytes.ts` utility:**  
  Added minimal helper functions — `fromHex`, `toHex`, `concat`, `createView`, and `reverse` — to replace essential `Buffer` functionality.  

- **Updated all source files:**  
  - **utility.ts:** Cryptographic and serialization functions now use `Uint8Array`.  
  - **interface.ts:** All type definitions updated from `Buffer` to `Uint8Array`.  
  - **transaction.ts:** Bitcoin transaction parsing optimized using `DataView` operations.  
  - **scanning.ts:** Silent payment output scanning logic migrated.  
  - **outputs.ts:** Output creation functionality updated.  
  - **encoding.ts:** Address encoding/decoding and block parsing migrated.  

###  Package-by-Package Results  

- **Esplora package:**  Clean (no `Buffer` usage found)  
- **Level package:**  Clean (no `Buffer` usage found)  
- **Wallet package:** ✅Successfully migrated  
  - **wallet.ts:** Updated with proper `Uint8Array` usage and `Buffer` conversions at library boundaries.  
  - **coin.ts:** Updated Taproot and P2WPKH handling.  
