### PR TITLE
fix: add dist/ to .gitignore 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
+dist
 dist-ssr
 *.local
 coverage


### PR DESCRIPTION
## Description
when doing npm run build outputs in dist/ directory could be accidentally committed to the repository. 