### PR TITLE
fix: correct output directory in esplora tsconfig.build.json

### DIFF
--- a/packages/esplora/tsconfig.build.json
+++ b/packages/esplora/tsconfig.build.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "declaration": false,
-    "outDir": "../../dist/level",
+    "outDir": "../../dist/esplora",
     "noEmit": false
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
- #80 
## Description
Changed outDir from `../../dist/level' to `../../dist/esplora` to ensure esplora package builds are output to the correct directory instead of conflicting with the level package output location.