### PR TITLE
 enhancement:-Add gap-limit address discovery on init

### DIFF
--- a/packages/wallet/test/address-discovery.spec.ts
+++ b/packages/wallet/test/address-discovery.spec.ts
@@ -1,0 +1,94 @@
+import * as fs from 'fs';
+import { mnemonicToSeedSync } from 'bip39';
+import BIP32Factory from 'bip32';
+import * as ecc from 'tiny-secp256k1';
+import { payments } from 'bitcoinjs-lib';
+import { regtest } from 'bitcoinjs-lib/src/networks';
+import { Buffer } from 'buffer';
+import { Wallet } from '../src';
+import { WalletDB } from '@silent-pay/level/src';
+import { Coin, NetworkInterface } from '../src';
+
+const bip32 = BIP32Factory(ecc);
+
+class MockNetworkClient implements NetworkInterface {
+    constructor(private readonly usedAddresses: Set<string>) {}
+
+    get network() {
+        return regtest;
+    }
+
+    async getLatestBlockHeight(): Promise<number> {
+        return 0;
+    }
+
+    async getLatestBlockHash(): Promise<string> {
+        return '0'.repeat(64);
+    }
+
+    async getBlockHash(_height: number): Promise<string> {
+        return '0'.repeat(64);
+    }
+
+    async getUTXOs(address: string): Promise<Coin[]> {
+        if (this.usedAddresses.has(address)) {
+            return [
+                new Coin({
+                    txid: '0'.repeat(64),
+                    vout: 0,
+                    value: 1000,
+                    address,
+                    status: { isConfirmed: true },
+                }),
+            ];
+        }
+        return [];
+    }
+
+    async getFeeRate(): Promise<number> {
+        return 1;
+    }
+
+    async broadcast(_tx: string): Promise<void> {
+        return;
+    }
+}
+
+describe('Wallet address discovery', () => {
+    const mnemonic =
+        'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+    const walletPath = './test/wallet-discovery';
+
+    const deriveAddress = (index: number, change: 0 | 1) => {
+        const seed = mnemonicToSeedSync(mnemonic).toString('hex');
+        const masterKey = bip32.fromSeed(Buffer.from(seed, 'hex'));
+        const child = masterKey.derivePath(`m/84'/0'/0'/${change}/${index}`);
+        return payments.p2wpkh({
+            pubkey: child.publicKey,
+            network: regtest,
+        }).address!;
+    };
+
+    it('should discover used addresses and persist depths', async () => {
+        const usedAddresses = new Set<string>([
+            deriveAddress(0, 0),
+            deriveAddress(2, 0),
+            deriveAddress(1, 1),
+        ]);
+
+        const walletDB = new WalletDB({ location: walletPath });
+        const wallet = new Wallet({
+            db: walletDB,
+            networkClient: new MockNetworkClient(usedAddresses),
+            gapLimit: 2,
+        });
+
+        await wallet.init({ mnemonic });
+
+        expect(await walletDB.getReceiveDepth()).toBe(3);
+        expect(await walletDB.getChangeDepth()).toBe(2);
+
+        await wallet.close();
+        fs.rmSync(walletPath, { recursive: true, force: true });
+    });
+});

--- a/packages/wallet/test/wallet.spec.ts
+++ b/packages/wallet/test/wallet.spec.ts
@@ -41,18 +41,22 @@ describe('Wallet', () => {
                 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
         });
         const allAddresses = await walletDB.getAllAddresses();
-        expect(allAddresses).toStrictEqual([
-            'bcrt1qcr8te4kr609gcawutmrza0j4xv80jy8zeqchgx',
-            'bcrt1qgl5vlg0zdl7yvprgxj9fevsc6q6x5dmcvenxlt',
-            'bcrt1qgswpjzsqgrm2qkfkf9kzqpw6642ptrgz4wwff7',
-            'bcrt1qhxgzmkmwvrlwvlfn4qe57lx2qdfg8physujr0f',
-            'bcrt1qm97vqzgj934vnaq9s53ynkyf9dgr05rat8p3ef',
-            'bcrt1qncdts3qm2guw3hjstun7dd6t3689qg42eqsfxf',
-            'bcrt1qnjg0jd8228aq7egyzacy8cys3knf9xvr3v5hfj',
-            'bcrt1qnpzzqjzet8gd5gl8l6gzhuc4s9xv0djt8vazj8',
-            'bcrt1qp59yckz4ae5c4efgw2s5wfyvrz0ala7rqr7utc',
-            'bcrt1qtet8q6cd5vqm0zjfcfm8mfsydju0a29gq0p9sl',
-        ]);
+        expect(allAddresses.length).toBe(40);
+        expect(allAddresses).toEqual(
+            expect.arrayContaining([
+                'bcrt1qcr8te4kr609gcawutmrza0j4xv80jy8zeqchgx',
+                'bcrt1qgl5vlg0zdl7yvprgxj9fevsc6q6x5dmcvenxlt',
+                'bcrt1qgswpjzsqgrm2qkfkf9kzqpw6642ptrgz4wwff7',
+                'bcrt1qhxgzmkmwvrlwvlfn4qe57lx2qdfg8physujr0f',
+                'bcrt1qm97vqzgj934vnaq9s53ynkyf9dgr05rat8p3ef',
+                'bcrt1qncdts3qm2guw3hjstun7dd6t3689qg42eqsfxf',
+                'bcrt1qnjg0jd8228aq7egyzacy8cys3knf9xvr3v5hfj',
+                'bcrt1qnpzzqjzet8gd5gl8l6gzhuc4s9xv0djt8vazj8',
+                'bcrt1qp59yckz4ae5c4efgw2s5wfyvrz0ala7rqr7utc',
+                'bcrt1qtet8q6cd5vqm0zjfcfm8mfsydju0a29gq0p9sl',
+                'bcrt1q8c6fshw2dlwun7ekn9qwf37cu2rn755ufhry49',
+            ]),
+        );
     });
 
     it('should set a new password, close and reopen the wallet with the same password', async () => {
@@ -66,14 +70,14 @@ describe('Wallet', () => {
         address = await wallet.deriveReceiveAddress();
         expect(address).toBe('bcrt1qcr8te4kr609gcawutmrza0j4xv80jy8zeqchgx');
         const allAddresses = await walletDB.getAllAddresses();
-        expect(allAddresses.length).toStrictEqual(11);
+        expect(allAddresses.length).toStrictEqual(40);
     });
 
     it('should derive second receive address', async () => {
         const address = await wallet.deriveReceiveAddress();
         expect(address).toBe('bcrt1qnjg0jd8228aq7egyzacy8cys3knf9xvr3v5hfj');
         const allAddresses = await walletDB.getAllAddresses();
-        expect(allAddresses.length).toStrictEqual(12);
+        expect(allAddresses.length).toStrictEqual(40);
     });
 
     it('should derive first change address', async () => {


### PR DESCRIPTION
Summary
Add gap‑limit address discovery during [Wallet.init()](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to recover prior funds without a preloaded DB.
Persist discovered receive/change depths and allow optional custom address usage checks.
Update wallet tests and add unit coverage for discovery logic.
Testing
Not run (not requested).
Notes
Default gap limit is 20, configurable via [WalletConfigOptions.gapLimit](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).